### PR TITLE
Fixed SEGV-bug while creating SDL_Window

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,4 +25,5 @@ This demo is based on a set of tutorials (mix and match):
 - Windows: Copy the SDL dll from *\Third-Party\Bin\ to the vulkansdldemo output directory
 - Windows: Run
 
-- Others: simply compile the main.cpp file and link to the vulkan and SDL library.
+- Others: Compile the main.cpp file and link to the vulkan and SDL2 library. 
+Example: `g++ main.cpp  -lSDL2 -lvulkan -lglm`

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -830,7 +830,11 @@ int main(int argc, char *argv[])
 		return -1;
 
 	// Create vulkan compatible window
-	SDL_Window* window = createWindow();
+        SDL_Window* window {createWindow()};
+        if (!window){
+	    SDL_Quit();
+	    return -1;
+        }
 
 	// Get available vulkan extensions, necessary for interfacing with native window
 	// SDL takes care of this call and returns, next to the default VK_KHR_surface a platform specific extension


### PR DESCRIPTION
In line 833: `SDL_Window* window = createWindow();` will return a null-pointe, on machines that do not support Vulkan.

